### PR TITLE
Fix typo in text_classification_cnn.R

### DIFF
--- a/Tutorials/Deep-Learning-for-Text-Classification-in-Azure/R/text_classification_cnn.R
+++ b/Tutorials/Deep-Learning-for-Text-Classification-in-Azure/R/text_classification_cnn.R
@@ -101,14 +101,14 @@ if(!file.exists(train.file.output)){
   text.encoder.csv(input.file=train.file.input, 
                    output.file=train.file.output, 
                    alphabet=alphabet, 
-                   max_text_lenght=feature.len,
+                   max.text.lenght=feature.len,
                    shuffle=TRUE)
 }
 if(!file.exists(test.file.output)){
   text.encoder.csv(input.file=test.file.input, 
                    output.file=test.file.output, 
                    alphabet=alphabet, 
-                   max_text_lenght=feature.len,
+                   max.text.lenght=feature.len,
                    shuffle=FALSE)
 }
 


### PR DESCRIPTION
`max_text_lenght` should be `max.text.lenght` as defined in https://github.com/Azure/Cortana-Intelligence-Gallery-Content/blob/master/Tutorials/Deep-Learning-for-Text-Classification-in-Azure/R/text_encoder.R#L22